### PR TITLE
honor insertTextFormat

### DIFF
--- a/plugin/asyncomplete-lsp.vim
+++ b/plugin/asyncomplete-lsp.vim
@@ -93,7 +93,11 @@ endfunction
 
 function! s:format_completion_item(item)
     if has_key(a:item, 'insertText') && !empty(a:item['insertText'])
-        let l:word = a:item['insertText']
+        if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] != 1
+            let l:word = a:item['label']
+        else
+            let l:word = a:item['insertText']
+        endif
         let l:abbr = a:item['label']
     else
         let l:word = a:item['label']


### PR DESCRIPTION
some lang servers such as rust sends snippets which we don't support it so default to label instead of insertText.

```
{
    "label": "about",
    "kind": 3,
    "insertTextFormat": 2,
    "insertText": "about(${1:about})",
    "detail": "pub fn about<S: Into<&'b str>>(mut self, about: S) -> Self"
}
```