### PR TITLE
Pass server name to get_vim_completion_item

### DIFF
--- a/plugin/asyncomplete-lsp.vim
+++ b/plugin/asyncomplete-lsp.vim
@@ -85,7 +85,7 @@ function! s:handle_completion(server_name, opt, ctx, data) abort
         let l:incomplete = 0
     endif
 
-    call map(l:items, 'lsp#omni#get_vim_completion_item(v:val)')
+    call map(l:items, 'lsp#omni#get_vim_completion_item(v:val, a:server_name)')
 
     let l:col = a:ctx['col']
     let l:typed = a:ctx['typed']


### PR DESCRIPTION
Adapts to change in vim-lsp: lsp#omni#get_vim_completion_item now takes the (optional) server name to allow for configurable custom mappings from kind id to text per server; see prabirshrestha/vim-lsp#524.

This change is needed to also show the custom names on autocomplete.