### PR TITLE
Fix refresh

### DIFF
--- a/plugin/asyncomplete-lsp.vim
+++ b/plugin/asyncomplete-lsp.vim
@@ -89,7 +89,7 @@ function! s:handle_completion(server_name, opt, ctx, data) abort
 
     let l:col = a:ctx['col']
     let l:typed = a:ctx['typed']
-    let l:kw = matchstr(l:typed, '\k\+$')
+    let l:kw = matchstr(l:typed, get(b:, 'asyncomplete_refresh_pattern', '\k\+$'))
     let l:kwlen = len(l:kw)
     let l:startcol = l:col - l:kwlen
 


### PR DESCRIPTION
Sorry, #28 was wrong. In concept of asyncomplete-lsp.vim, start position of completion should be decided by asyncomplet itself since user may exit insert mode.

```
conso<ESC>ale.
```

The start position must always be at `c` not `a`. But #24 break this. So I revert previous change. And add `b:asyncomplete_refresh_pattern` to customize the pattern from vim-lsp-settings. Modifying `iskeyword` may make new issue.