### PR TITLE
Use vim-lsp's startcol if possible (See https://github.com/prabirshrestha/vim-lsp/pull/1236)

### DIFF
--- a/plugin/asyncomplete-lsp.vim
+++ b/plugin/asyncomplete-lsp.vim
@@ -97,6 +97,7 @@ function! s:handle_completion(server, position, opt, ctx, data) abort
     let l:kw = matchstr(l:typed, get(b:, 'asyncomplete_refresh_pattern', '\k\+$'))
     let l:kwlen = len(l:kw)
     let l:startcol = l:col - l:kwlen
+    let l:startcol = min([l:startcol, get(l:completion_result, 'startcol', l:startcol)])
 
     call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:completion_result['items'], l:completion_result['incomplete'])
 endfunction


### PR DESCRIPTION
This PR aims to support textEdit.range.start.character as a completion startcol.

I tested this with deno lsp.

https://user-images.githubusercontent.com/629908/146577529-f518d25c-e321-408e-97f2-faa2acf232ea.mp4


