### PR TITLE
fix inline completion with pumvisible()

### DIFF
--- a/plugin/asyncomplete-lsp.vim
+++ b/plugin/asyncomplete-lsp.vim
@@ -139,7 +139,7 @@ function! s:handle_inline_completion(server, position, opt, ctx, bufnr, data) ab
     endif
 endfunction
 
-inoremap <expr> <Plug>(asyncomplete_lsp_inline_complete_accept) (pumvisible() && complete_info()['selected'] == -1 ? "\<C-e>" : "") .. "<c-r>=<SID>accept_inline_completion()<cr>"
+inoremap <expr> <Plug>(asyncomplete_lsp_inline_complete_accept) (pumvisible() <Bar><Bar> complete_info()['selected'] == -1 ? "\<C-e>" : "") .. "<c-r>=<SID>accept_inline_completion()<cr>"
 
 function! s:accept_inline_completion() abort
     if !exists('b:vim_lsp_inline_completion_text') || empty(b:vim_lsp_inline_completion_text)


### PR DESCRIPTION
broken condition for inline completion. Wrong result when there are no selection with pumvisible().